### PR TITLE
Envfile support

### DIFF
--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -20,7 +20,10 @@ var spawn = require('child_process').spawn;
 var execSync = require('child_process').execSync;
 var psTree = require('ps-tree');
 var winPsTree = require('winpstree');
-
+var env = require('dotenv');
+var fs = require('fs');
+var path = require('path');
+var dotenv = require('dotenv');
 
 module.exports = function() {
   var isWin = /^win/.test(process.platform);
@@ -43,7 +46,7 @@ module.exports = function() {
         envArgs += 'set ' + key + '=' + containerEnv[key] + '&&';
       }
       else {
-        envArgs += 'export ' + key + '=' + containerEnv[key] + ';';
+        envArgs += key + '=' + containerEnv[key] + ' ';
       }
     });
     return envArgs;
@@ -52,24 +55,34 @@ module.exports = function() {
 
 
   var run = function(mode, container, exitCb, cb) {
-    var toExec;
-    var cmd;
-    var cwd;
+    var cmd = container.specific.execute.exec;
+    var cwd = container.specific.path;
+    var envFile = getEnvFile(container);
+
     var env;
+    var toExec;
     var child = {};
     var envArgs = '';
+    var envFileArgs = '';
     var called = false;
 
-    cmd = container.specific.execute.exec;
-    cwd = container.specific.path;
     if (cmd.slice(0, 5) === 'node ' && cmd.slice(0, 7) !== 'node -r') {
       // use same node running fuge
       cmd = process.argv[0] + ' -r fuge ' + cmd.slice(5);
       container.type = 'node';
     }
 
+    if (envFile && !fs.existsSync(envFile)) {
+      return cb('Env File: ' + envFile + ' does not exist');
+    }
+
     if (container.specific && container.specific.environment) {
       envArgs = generateEnvironment(container.specific.environment);
+    }
+
+    if (envFile) {
+      var envFileData = dotenv.parse(fs.readFileSync(envFile));
+      envArgs += ' ' + generateEnvironment(envFileData || {});
     }
 
     if (isWin) {
@@ -79,7 +92,10 @@ module.exports = function() {
       toExec = envArgs + ' exec ' + cmd;
     }
 
+
     toExec = handleIpAddress(container, toExec);
+
+    console.log('running: ' + toExec);
 
     env = Object.create(process.env);
     if (mode !== 'preview') {
@@ -113,11 +129,19 @@ module.exports = function() {
     }
     else {
       child.detail = { cmd: cmd,
-                       environment: container.specific.environment,
-                       cwd: cwd };
+        environment: container.specific.environment,
+        cwd: cwd };
     }
 
     cb(null, child);
+
+
+
+    function getEnvFile(container) {
+      var envFile = container.specific.source.env_file;
+      var yamlPath = container.specific.yamlPath;
+      return envFile && path.resolve(path.dirname(yamlPath), envFile);
+    }
   };
 
 

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -72,7 +72,7 @@ module.exports = function() {
     }
 
     if (envFile && !fs.existsSync(envFile)) {
-      return cb('Env File: ' + envFile + ' does not exist');
+      return cb('Error: ' + envFile + ' does not exist');
     }
 
     if (container.specific && container.specific.environment) {

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -20,7 +20,6 @@ var spawn = require('child_process').spawn;
 var execSync = require('child_process').execSync;
 var psTree = require('ps-tree');
 var winPsTree = require('winpstree');
-var env = require('dotenv');
 var fs = require('fs');
 var path = require('path');
 var dotenv = require('dotenv');

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "chalk": "^1.1.1",
     "chokidar": "^1.2.0",
     "chokidar-child": "^0.1.1",
+    "dotenv": "^2.0.0",
     "lodash": "^3.10.1",
     "ps-tree": "^1.0.1",
     "simple-grep": "0.0.2",


### PR DESCRIPTION
will load up env files, the same as docker-compose does, which allows you to specify credentials in a way that doesn't need to be comitted into the codebase