### PR TITLE
replaced simple-grep npm dep with a local version until perm solution

### DIFF
--- a/lib/simple-grep.js
+++ b/lib/simple-grep.js
@@ -1,0 +1,55 @@
+/*jshint -W069 */
+/*
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+module.exports = function(what, where, callback) {
+	var exec = require('child_process').exec;
+
+	exec('grep ' + what + ' ' + where + ' -nr', function(err, stdin) {
+		var list = {};
+		var results = stdin.split('\n');
+
+    // remove last element (it’s an empty line)
+    results.pop();
+
+    for (var x = 0; x < results.length; x++) {
+      var eachPart1 = results[x].split(':'); //file:linenum:line
+      list[eachPart1[0]] = [];
+    }
+
+    for (var i = 0; i < results.length; i++) {
+      var eachPart = results[i].split(':'); //file:linenum:line
+      var details = {};
+      var filename = eachPart[0];
+      details['line_number'] = eachPart[1];
+
+      eachPart.shift();
+      eachPart.shift();
+      details.line = eachPart.join(':');
+
+      list[filename].push(details);
+    }
+
+
+    var res = [];
+    var files = Object.keys(list);
+    for(var a = 0; a < files.length; a++) {
+      res.push({ 'file' : files[a], 'results' : list[files[a]] });
+    }
+
+    callback(res);
+	});
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,8 +20,8 @@ var stream = require('stream');
 var async = require('async');
 var _ = require('lodash');
 var chalk = require('chalk');
-var sgrep = require('simple-grep');
 var readline = require('readline');
+var sgrep = require('./simple-grep');
 
 
 module.exports = function() {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "dotenv": "^2.0.0",
     "lodash": "^3.10.1",
     "ps-tree": "^1.0.1",
-    "simple-grep": "0.0.2",
     "winpstree": "^0.1.0"
   },
   "repository": {
@@ -34,11 +33,11 @@
     "url": "https://github.com/apparatus/fuge-runner"
   },
   "scripts": {
-    "lint": "jshint --exclude ./node_modules **/*.js",
-    "test": "jshint --exclude ./node_modules **/*.js && tape test/*Test.js | tap-spec",
+    "lint": "jshint --exclude /node_modules,/test,/coverage .",
+    "test": "jshint --exclude /node_modules,/test,/coverage . && tape test/*Test.js | tap-spec",
     "coverage": "istanbul cover tape **/*Test.js && open ./coverage/lcov-report/index.html",
     "coverage-check": "istanbul cover tape test/*Test.js && istanbul check-coverage",
-    "commit-check": "jshint --exclude ./node_modules **/*.js && tape test/*Test.js | tap-spec"
+    "commit-check": "jshint --exclude /node_modules,/test,/coverage . && tape test/*Test.js | tap-spec"
   },
   "pre-commit": [
     "commit-check"

--- a/run-0x.js
+++ b/run-0x.js
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('0x/cmd')
+require('0x/cmd');


### PR DESCRIPTION
fix for: https://github.com/apparatus/fuge-runner/issues/9

simple-grep was removed from npm. short term workaround, added simple-grep source to ./lib/simple-grep.js. updated package.json script commands to ignore node_modules, tests, and coverage dir. test dir is being ignored because there's an ass load of linting puke.