### PR TITLE
Backported  to simple-grep@0.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dotenv": "^2.0.0",
     "lodash": "^3.10.1",
     "ps-tree": "^1.0.1",
-    "simple-grep": "0.0.2",
+    "simple-grep": "0.0.1",
     "winpstree": "^0.1.0"
   },
   "repository": {


### PR DESCRIPTION
simple-grep@0.0.2 has been removed, so back porting to simple-grep@0.0.1
