### PR TITLE
replace fuge with process.argv[1]

### DIFF
--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -66,7 +66,7 @@ module.exports = function() {
 
     if (cmd.slice(0, 5) === 'node ' && cmd.slice(0, 7) !== 'node -r') {
       // use same node running fuge
-      cmd = process.argv[0] + ' -r fuge ' + cmd.slice(5);
+      cmd = process.argv[0] + ' -r '+ process.argv[1] + ' ' + cmd.slice(5);
       container.type = 'node';
     }
 


### PR DESCRIPTION
With the current implementation I get the following error when I try to execute `fuge run compose-dev.yml`:
``` 
[service1 - 49563]: module.js:327
    throw err;
    ^

Error: Cannot find module 'fuge'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at module.js:498:12
    at Array.forEach (native)
    at Function.Module._preloadModules (module.js:497:12)
    at Function.startup.preloadModules (node.js:861:38)
    at startup (node.js:117:17)
[service1 - 49563]:     at node.js:968:3
process exit [49563]: service1
```
I'm not sure whats wrong, but maybe it's because I use nvm.
Using process.argv[1] fixes that problem.