### PR TITLE
Use split2 and pump to render colored output

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -16,7 +16,8 @@
 'use strict';
 
 var fs = require('fs');
-var stream = require('stream');
+var split = require('split2');
+var pump = require('pump');
 var async = require('async');
 var _ = require('lodash');
 var chalk = require('chalk');
@@ -82,27 +83,23 @@ module.exports = function() {
 
 
   var streamOutput = function(proc, config) {
-    var stdOutStream = new stream.Writable();
+    var colorizer = split(function(line) {
+      return proc.colour('[' + proc.identifier + ' - ' + proc.child.pid + ']: ' + line) + '\n';
+    });
+    var errorColorizer = split(function(line) {
+      return chalk.red('[' + proc.identifier + ' - ' + proc.child.pid + ']: ' + line) + '\n';
+    });
     var logStream = fs.createWriteStream(config.logPath + '/' + proc.identifier + '.log');
 
-    stdOutStream._write = function(chunk, encoding, done) {
-      logStream.write(chunk.toString());
-      if (proc.tail) {
-        process.stdout.write(proc.colour('[' + proc.identifier + ' - ' + proc.child.pid + ']: ' + chunk.toString()));
-      }
-      done();
-    };
-    proc.child.stdout.pipe(stdOutStream);
+    if (proc.tail) {
+      pump(proc.child.stdout, colorizer);
+      colorizer.pipe(process.stdout, { end: false });
+      pump(proc.child.stderr, errorColorizer);
+      errorColorizer.pipe(process.stdout, { end: false });
+    }
 
-    var stdErrStream = new stream.Writable();
-    stdErrStream._write = function(chunk, encoding, done) {
-      logStream.write(chunk.toString());
-      if (proc.tail) {
-        process.stdout.write(chalk.red('[' + proc.identifier + ' - ' + proc.child.pid + ']: ' + chunk.toString()));
-      }
-      done();
-    };
-    proc.child.stderr.pipe(stdErrStream);
+    pump(process.child.stdout, logStream);
+    pump(process.child.stderr, logStream);
   };
 
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -98,8 +98,8 @@ module.exports = function() {
       errorColorizer.pipe(process.stdout, { end: false });
     }
 
-    pump(process.child.stdout, logStream);
-    pump(process.child.stderr, logStream);
+    pump(proc.child.stdout, logStream);
+    pump(proc.child.stderr, logStream);
   };
 
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "dotenv": "^2.0.0",
     "lodash": "^3.10.1",
     "ps-tree": "^1.0.1",
+    "pump": "^1.0.1",
     "simple-grep": "0.0.1",
+    "split2": "^2.1.0",
     "winpstree": "^0.1.0"
   },
   "repository": {


### PR DESCRIPTION
Please check and test this one.
It uses split2 to divide the log lines line by line, to avoid issues with OS buffering.

@davidmarkclements 
@pelger 
@rjrodger