### PR TITLE
Winfix

### DIFF
--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -16,7 +16,7 @@
 
 var _ = require('lodash');
 var async = require('async');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var execSync = require('child_process').execSync;
 var psTree = require('ps-tree');
 var winPsTree = require('winpstree');

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -108,6 +108,10 @@ module.exports = function() {
       }
 
       if (isWin) {
+        // allows quoted args to cmd.exe
+        options.windowsVerbatimArguements = true
+
+        // /s encodes inner quotes so the whole command itself can be quoted correctly
         child = spawn(process.env.comspec, ['/s', '/c', '"', toExec, '"'], options);
       }
       else {

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -109,7 +109,7 @@ module.exports = function() {
 
       if (isWin) {
         // allows quoted args to cmd.exe
-        options.windowsVerbatimArguements = true;
+        options.windowsVerbatimArguments = true;
 
         // /s encodes inner quotes so the whole command itself can be quoted correctly
         child = spawn(process.env.comspec, ['/s', '/c', '"', toExec, '"'], options);

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -109,7 +109,7 @@ module.exports = function() {
 
       if (isWin) {
         // allows quoted args to cmd.exe
-        options.windowsVerbatimArguements = true
+        options.windowsVerbatimArguements = true;
 
         // /s encodes inner quotes so the whole command itself can be quoted correctly
         child = spawn(process.env.comspec, ['/s', '/c', '"', toExec, '"'], options);

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -16,7 +16,7 @@
 
 var _ = require('lodash');
 var async = require('async');
-var spawn = require('cross-spawn');
+var spawn = require('child_process').spawn;
 var execSync = require('child_process').execSync;
 var psTree = require('ps-tree');
 var winPsTree = require('winpstree');
@@ -67,7 +67,11 @@ module.exports = function() {
     if (cmd.slice(0, 5) === 'node ' && cmd.slice(0, 7) !== 'node -r') {
       // use same node running fuge
       var fugePath = process.mainModule.filename;
-      cmd = process.argv[0] + ' -r ' + fugePath + ' ' + cmd.slice(5);
+
+      // quote windows path to handle potential spaces
+      var nodePath = isWin ? ('"' + process.argv[0] + '"') : process.argv[0];
+
+      cmd = nodePath + ' -r ' + fugePath + ' ' + cmd.slice(5);
       container.type = 'node';
     }
 
@@ -104,7 +108,7 @@ module.exports = function() {
       }
 
       if (isWin) {
-        child = spawn(process.env.comspec, ['/c', toExec], options);
+        child = spawn(process.env.comspec, ['/s', '/c', '"', toExec, '"'], options);
       }
       else {
         child = spawn('/bin/bash', ['-c', toExec], options);

--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -99,7 +99,7 @@ module.exports = function() {
     env = Object.create(process.env);
     if (mode !== 'preview') {
       var options = {cwd: cwd, env: env, stdio: [0, 'pipe', 'pipe'], detached: false};
-      if (container.type === 'node') {
+      if (container.type === 'node' && !isWin) {
         options.stdio[3] = 'ipc';
       }
 


### PR DESCRIPTION
This fixes the issue of node's default installation being in a path that has spaces in it. There is a lot more we can do hear to hard up Windows support but this will fix the immediate issues of #15 and #16 

@mcollina Could you have a quick look over before I merge?

I want to test it a bit more before I push a release so for now npm link. I simply don't trust the tests to tell me if I have broken anything or not.

@lucamaraschi we need to add this to our actions, some automation around testing windows paths and max paths and all that Jazz.