### PR TITLE
allow dashes in env vars

### DIFF
--- a/lib/processRunner.js
+++ b/lib/processRunner.js
@@ -39,12 +39,12 @@ module.exports = function () {
 
 
   var generateEnvironment = function (containerEnv) {
-    var envArgs = ' '
+    var envArgs = isWin ? ' ' : 'env '
     _.each(_.keys(containerEnv), function (key) {
       if (isWin) {
         envArgs += 'set ' + key + '=' + containerEnv[key] + '&&'
       } else {
-        envArgs += key + '=' + containerEnv[key] + ' '
+        envArgs += '"' + key + '=' + containerEnv[key] + '" '
       }
     })
     return envArgs
@@ -91,8 +91,9 @@ module.exports = function () {
     if (isWin) {
       toExec = envArgs + ' ' + cmd
     } else {
-      toExec = envArgs + ' exec ' + cmd
+      toExec = envArgs + 'bash -c "exec ' + cmd + '"'
     }
+
 
 
     toExec = handleIpAddress(container, toExec)


### PR DESCRIPTION
allows dashes in env vars, compliment to https://github.com/apparatus/xeno-compose/pull/8

windows already allows dashes in env vars (`> set a-b=c && node -p process.env['a-b'] # c`)