### PR TITLE
Pass environment to containers

### DIFF
--- a/lib/support/dockerRunner.js
+++ b/lib/support/dockerRunner.js
@@ -74,7 +74,8 @@ module.exports = function () {
       HostConfig: {
         ExposedPorts: ep,
         PortBindings: pb
-      }
+      },
+      Env: Object.entries(container.environment).map(([key, value]) => `${key}=${value}`)
     }
 
     if (mode === 'preview') {

--- a/test/dockerRunner.test.js
+++ b/test/dockerRunner.test.js
@@ -27,12 +27,13 @@ function exitCb () {
 
 
 test('docker runner test', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var runner = dockerRunner()
 
   config.load(path.join(__dirname, 'fixture', 'system', 'fuge', 'containers.yml'), function (err, system) {
     t.equal(err, null)
+    t.equal(system.topology.containers.wibble.environment.FOO, "BAR");
     runner.start(system, 'live', system.topology.containers.wibble, exitCb, function (err, child) {
       t.equal(null, err)
       t.notEqual(undefined, child.pid)

--- a/test/fixture/system/fuge/containers.yml
+++ b/test/fixture/system/fuge/containers.yml
@@ -11,6 +11,8 @@ wibble:
   type: container
   image: wibble
   args: ''
+  environment:
+    - "FOO=BAR"
   ports:
     - main=27017:27017
 fish:


### PR DESCRIPTION
Environment variables were not being added to contianer creation.
This adds the Env variable with name=value string pairs for Docker.
Includes an updated test for checking the environment.